### PR TITLE
Fix paging in todo

### DIFF
--- a/todoApp/spec/main.tsp
+++ b/todoApp/spec/main.tsp
@@ -203,21 +203,21 @@ namespace TodoItems {
     /** The items in the page */
     items: TodoItem[];
 
-    pagination: {
-      /** The number of items returned in this page */
-      pageSize: int32;
+    /** The number of items returned in this page */
+    pageSize: int32;
 
-      /** The total number of items */
-      totalSize: int32;
+    /** The total number of items */
+    totalSize: int32;
 
-      ...PaginationControls;
+    ...PaginationControls;
 
-      /** A link to the previous page, if it exists */
-      prevLink?: url;
+    /** A link to the previous page, if it exists */
+    @prevLink
+    prevLink?: url;
 
-      /** A link to the next page, if it exists */
-      nextLink?: url;
-    };
+    /** A link to the next page, if it exists */
+    @nextLink
+    nextLink?: url;
   }
 
   // deeply annoying that I have to copy/paste this...


### PR DESCRIPTION
- Add the missing decorators `@nextLink` and `@prevLink`
- Remove nested pagination link, waiting on https://github.com/microsoft/typespec/issues/5208 to be fixed (and client codegen wouldn't support nested pagination links anyway)