### PR TITLE
add @error decorator to pre-defined error responses

### DIFF
--- a/todoApp/spec/main.tsp
+++ b/todoApp/spec/main.tsp
@@ -245,13 +245,6 @@ namespace TodoItems {
   @error
   model NotFoundErrorResponse is NotFoundResponse;
 
-  /**
-   * We need to decorate NoContentResponse with an explicit `@error` decorator so it's clear that
-   * it is not a valid response
-   */
-  @error
-  model NoContentErrorResponse is NoContentResponse;
-
   model Page<T> {
     @pageItems items: T[];
   }
@@ -273,7 +266,7 @@ namespace TodoItems {
   ): TodoItem;
   @delete op delete(
     @path id: TodoItem.id,
-  ): WithStandardErrors<NoContentErrorResponse | NotFoundErrorResponse>;
+  ): WithStandardErrors<NoContentResponse | NotFoundErrorResponse>;
 
   @route("{itemId}/attachments")
   namespace Attachments {
@@ -286,6 +279,6 @@ namespace TodoItems {
     op createAttachment(
       @path itemId: TodoItem.id,
       @body contents: TodoAttachment,
-    ): WithStandardErrors<NoContentErrorResponse | NotFoundErrorResponse>;
+    ): WithStandardErrors<NoContentResponse | NotFoundErrorResponse>;
   }
 }

--- a/todoApp/spec/main.tsp
+++ b/todoApp/spec/main.tsp
@@ -238,12 +238,11 @@ namespace TodoItems {
     @statusCode statusCode: 422;
   }
 
-  /**
-   * We need to decorate NotFoundResponse with an explicit `@error` decorator so it's clear that
-   * it is not a valid response
-   */
   @error
-  model NotFoundErrorResponse is NotFoundResponse;
+  model NotFoundErrorResponse {
+     @statusCode statusCode: 404;
+     code: "not-found";
+  }
 
   model Page<T> {
     @pageItems items: T[];

--- a/todoApp/spec/main.tsp
+++ b/todoApp/spec/main.tsp
@@ -238,6 +238,20 @@ namespace TodoItems {
     @statusCode statusCode: 422;
   }
 
+  /**
+   * We need to decorate NotFoundResponse with an explicit `@error` decorator so it's clear that
+   * it is not a valid response
+   */
+  @error
+  model NotFoundErrorResponse is NotFoundResponse;
+
+  /**
+   * We need to decorate NoContentResponse with an explicit `@error` decorator so it's clear that
+   * it is not a valid response
+   */
+  @error
+  model NoContentErrorResponse is NoContentResponse;
+
   model Page<T> {
     @pageItems items: T[];
   }
@@ -251,7 +265,7 @@ namespace TodoItems {
     attachments?: TodoAttachment[],
   ): WithStandardErrors<TodoItem | InvalidTodoItem>;
 
-  @get op get(@path id: TodoItem.id): TodoItem | NotFoundResponse;
+  @get op get(@path id: TodoItem.id): TodoItem | NotFoundErrorResponse;
   @patch op update(
     @header contentType: "application/merge-patch+json",
     @path id: TodoItem.id,
@@ -259,19 +273,19 @@ namespace TodoItems {
   ): TodoItem;
   @delete op delete(
     @path id: TodoItem.id,
-  ): WithStandardErrors<NoContentResponse | NotFoundResponse>;
+  ): WithStandardErrors<NoContentErrorResponse | NotFoundErrorResponse>;
 
   @route("{itemId}/attachments")
   namespace Attachments {
     @list op list(
       @path itemId: TodoItem.id,
-    ): WithStandardErrors<Page<TodoAttachment> | NotFoundResponse>;
+    ): WithStandardErrors<Page<TodoAttachment> | NotFoundErrorResponse>;
 
     @sharedRoute
     @post
     op createAttachment(
       @path itemId: TodoItem.id,
       @body contents: TodoAttachment,
-    ): WithStandardErrors<NoContentResponse | NotFoundResponse>;
+    ): WithStandardErrors<NoContentErrorResponse | NotFoundErrorResponse>;
   }
 }


### PR DESCRIPTION
The client emitters (and probably other emitters as well) need an explicit `@error` decorator to `NotFoundResponse` and other error responses defined in the compiler. The reason is responses like `emitters` are defined as `Response<404>`. Unless we hardcode `404` to mean "error", we aren't able to determine that a `NotFoundResponse` is an error in our emitters. We don't want to hardcode, because what if a user wanted to specify a valid `404` response (or at least a `404` response where we don't throw an error?). This does beg the question for me if we should decorate these in core / if there's something else to be done here since it seems like in 99% of cases, this is an error type