### PR TITLE
Update 1.0-E2E-status for JS

### DIFF
--- a/1.0-E2E-status.md
+++ b/1.0-E2E-status.md
@@ -131,7 +131,7 @@ Legend:
 |                              | Python       | Yuchao    | :green_circle:           | 12/31   | [Code](https://github.com/allenjzhang/typespec-e2e-demo/tree/main/petstore/clients/python) |             |
 | ToDo App                     |              |           |                          |         |          |             |
 |                              | C#           | Dapeng    | :running_man:            | 1/15    | [Code](https://github.com/allenjzhang/typespec-e2e-demo/tree/main/todoApp/clients/dotnet) |             |
-|                              | JS           | Qiaoqiao  | :running_man:            | 1/15    | [Code](https://github.com/allenjzhang/typespec-e2e-demo/pull/31/files)        | we have a few features blocked by tcgc sdk method adoption [link](https://github.com/Azure/autorest.typescript/issues?q=is%3Aissue%20state%3Aopen%20label%3Ablocked)            |
+|                              | JS           | Qiaoqiao  | :running_man:            | 1/15    | [Code](https://github.com/allenjzhang/typespec-e2e-demo/pull/31/files)        |             |
 |                              | Java         | Weidong   | :green_circle:            | 1/15    | [Code](https://github.com/allenjzhang/typespec-e2e-demo/tree/main/todoApp/clients/java) |            |
 |                              | Python       | Yuchao    | :running_man:            | 1/15    | [Code](https://github.com/allenjzhang/typespec-e2e-demo/tree/main/todoApp/clients/python) |             |
 | Chat                         |              |           |                          |         |          |             |


### PR DESCRIPTION
We have finished the SDK method adoption PR, the blocker should not exist any more.