### PR TITLE
Java version bump for 0.64

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,24 +5,24 @@
   "packages": {
     "": {
       "dependencies": {
-        "@azure-tools/typespec-autorest": "^0.49.0",
-        "@azure-tools/typespec-azure-core": "^0.49.0",
-        "@azure-tools/typespec-azure-resource-manager": "^0.49.0",
-        "@azure-tools/typespec-client-generator-core": "^0.49.1",
+        "@azure-tools/typespec-autorest": "^0.50.0",
+        "@azure-tools/typespec-azure-core": "^0.50.0",
+        "@azure-tools/typespec-azure-resource-manager": "^0.50.0",
+        "@azure-tools/typespec-client-generator-core": "^0.50.0",
         "@azure-tools/typespec-ts": "^0.37.0",
-        "@typespec/compiler": "^0.63.0",
-        "@typespec/http": "^0.63.0",
+        "@typespec/compiler": "^0.64.0",
+        "@typespec/http": "^0.64.0",
         "@typespec/http-client-csharp": "^0.1.9-alpha.20250113.2",
-        "@typespec/http-client-java": "^0.1.6",
+        "@typespec/http-client-java": "^0.1.7",
         "@typespec/http-client-python": "^0.6.0",
         "@typespec/http-server-csharp": "https://artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvNDQ2MjEzMi9hcnRpZmFjdE5hbWUvcGFja2FnZXM1/content?format=file&subPath=%2Ftypespec-http-server-csharp-0.58.0-alpha.7-pr-5505.20250108.43.tgz",
         "@typespec/http-server-javascript": "^0.58.0-alpha.6",
-        "@typespec/json-schema": "^0.63.0",
-        "@typespec/openapi": "^0.63.0",
-        "@typespec/openapi3": "^0.63.0",
-        "@typespec/rest": "^0.63.0",
-        "@typespec/streams": "^0.63.0",
-        "@typespec/versioning": "^0.63.0"
+        "@typespec/json-schema": "^0.64.0",
+        "@typespec/openapi": "^0.64.0",
+        "@typespec/openapi3": "^0.64.0",
+        "@typespec/rest": "^0.64.0",
+        "@typespec/streams": "^0.64.0",
+        "@typespec/versioning": "^0.64.0"
       }
     },
     "node_modules/@apidevtools/swagger-methods": {
@@ -91,40 +91,40 @@
       }
     },
     "node_modules/@azure-tools/typespec-autorest": {
-      "version": "0.49.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-autorest/-/typespec-autorest-0.49.0.tgz",
-      "integrity": "sha512-stwfhmEc3yPeXbM8yfLKVCtaX5mR0H+sL74Xy/eMdEWoJgiE3aJxkgRWESu/7/vo99vugzo/HRwIEO5ELnyfRg==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-autorest/-/typespec-autorest-0.50.0.tgz",
+      "integrity": "sha512-CYzqN11NGU2HNJcycph7HCpjQoOR+XzyySDi6Z6rsXhZa/XTPDYJtmGHNVHXYGgvxJPxPJ9jm13DiLf/ReJnSA==",
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "~0.49.0",
-        "@azure-tools/typespec-azure-resource-manager": "~0.49.0",
-        "@azure-tools/typespec-client-generator-core": "~0.49.0",
-        "@typespec/compiler": "~0.63.0",
-        "@typespec/http": "~0.63.0",
-        "@typespec/openapi": "~0.63.0",
-        "@typespec/rest": "~0.63.0",
-        "@typespec/versioning": "~0.63.0"
+        "@azure-tools/typespec-azure-core": "~0.50.0",
+        "@azure-tools/typespec-azure-resource-manager": "~0.50.0",
+        "@azure-tools/typespec-client-generator-core": "~0.50.0",
+        "@typespec/compiler": "~0.64.0",
+        "@typespec/http": "~0.64.0",
+        "@typespec/openapi": "~0.64.0",
+        "@typespec/rest": "~0.64.0",
+        "@typespec/versioning": "~0.64.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-core": {
-      "version": "0.49.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.49.0.tgz",
-      "integrity": "sha512-hNKy+aePmPkB1brHQkO1tsJXqXPzt/9ehy10dv0rKdp9xq5dE3yBctHF5Aj3Nr8kr8GRG5z4KYpYPbV5guoT5w==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.50.0.tgz",
+      "integrity": "sha512-6kUhWNQc4Btgx7rIbx3dubBLst73qv04dGWg0yNoVi86iIXy+8wr4ee6pgk+niMsZDeHEBEWeeLy9VwCg3MgTg==",
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "~0.63.0",
-        "@typespec/http": "~0.63.0",
-        "@typespec/rest": "~0.63.0"
+        "@typespec/compiler": "~0.64.0",
+        "@typespec/http": "~0.64.0",
+        "@typespec/rest": "~0.64.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-resource-manager": {
-      "version": "0.49.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.49.0.tgz",
-      "integrity": "sha512-1xWuG8OBJDykYM6BFD2owV9WH+oC32zt7XteXA0T4nH2T+D+sEFKppkCOMtIjX7ENBAlecmbdwgSNTZYQf4vaw==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.50.0.tgz",
+      "integrity": "sha512-ekLAyPyy9eMMqdi3pj3g+iw9NNiK6ObDIU/W/bwSBSPwN2Po9d46fb65vcsjPeEkBceeRIPP6p54QtG9JYhSfg==",
       "dependencies": {
         "change-case": "~5.4.4",
         "pluralize": "^8.0.0"
@@ -133,12 +133,12 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "~0.49.0",
-        "@typespec/compiler": "~0.63.0",
-        "@typespec/http": "~0.63.0",
-        "@typespec/openapi": "~0.63.0",
-        "@typespec/rest": "~0.63.0",
-        "@typespec/versioning": "~0.63.0"
+        "@azure-tools/typespec-azure-core": "~0.50.0",
+        "@typespec/compiler": "~0.64.0",
+        "@typespec/http": "~0.64.0",
+        "@typespec/openapi": "~0.64.0",
+        "@typespec/rest": "~0.64.0",
+        "@typespec/versioning": "~0.64.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-rulesets": {
@@ -157,10 +157,9 @@
       }
     },
     "node_modules/@azure-tools/typespec-client-generator-core": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.49.1.tgz",
-      "integrity": "sha512-uAzlkYfL73lp1BnP8HMcIcS8iud7UnQzw6bf6FCUkKFO1B6wDwcvut3HfTtUj1kvw0XkiVJ0NkcxT0Dz0cylpQ==",
-      "license": "MIT",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.50.0.tgz",
+      "integrity": "sha512-Zk62SZb6W5neTtajcQAKll4zYSf3aKaMEDLymMTajXTsWxAlrb7sqnc8vTZWSIymaRI0A9olEL2luw9OLywUYA==",
       "dependencies": {
         "change-case": "~5.4.4",
         "pluralize": "^8.0.0",
@@ -170,12 +169,12 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "~0.49.0",
-        "@typespec/compiler": "~0.63.0",
-        "@typespec/http": "~0.63.0",
-        "@typespec/openapi": "~0.63.0",
-        "@typespec/rest": "~0.63.0",
-        "@typespec/versioning": "~0.63.0"
+        "@azure-tools/typespec-azure-core": "~0.50.0",
+        "@typespec/compiler": "~0.64.0",
+        "@typespec/http": "~0.64.0",
+        "@typespec/openapi": "~0.64.0",
+        "@typespec/rest": "~0.64.0",
+        "@typespec/versioning": "~0.64.0"
       }
     },
     "node_modules/@azure-tools/typespec-ts": {
@@ -822,9 +821,9 @@
       "license": "MIT"
     },
     "node_modules/@typespec/compiler": {
-      "version": "0.63.0",
-      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-0.63.0.tgz",
-      "integrity": "sha512-cC3YniwbFghn1fASX3r1IgNjMrwaY4gmzznkHT4f/NxE+HK4XoXWn4EG7287QgVMCaHUykzJCIfW9k7kIleW5A==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-0.64.0.tgz",
+      "integrity": "sha512-LnQGlQMWyqvhGg4Z9iyr5qSBTjI9zd49sodbEJbLafrxbj9pbHyjfSFbvt60gVbfuNvLErsdXvZiqqXV5nZdmQ==",
       "dependencies": {
         "@babel/code-frame": "~7.25.7",
         "ajv": "~8.17.1",
@@ -850,15 +849,15 @@
       }
     },
     "node_modules/@typespec/http": {
-      "version": "0.63.0",
-      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-0.63.0.tgz",
-      "integrity": "sha512-SYVbBmLPAPdWZfdMs0QlbpTnFREDnkINu2FR+0kRX12qzbRgpRbLsdhg59qx4TfKoh4IAPgSV+Fq84w7BWGsyQ==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-0.64.0.tgz",
+      "integrity": "sha512-vyyZP3Woo7or/2Oiq1fH+R0X/4WOBDjAlGsb9tLQzswfQHp710kNfiecA10y9gDC/9h+PjKsTElS1RcRRanpwA==",
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "~0.63.0",
-        "@typespec/streams": "~0.63.0"
+        "@typespec/compiler": "~0.64.0",
+        "@typespec/streams": "~0.64.0"
       },
       "peerDependenciesMeta": {
         "@typespec/streams": {
@@ -885,10 +884,9 @@
       }
     },
     "node_modules/@typespec/http-client-java": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@typespec/http-client-java/-/http-client-java-0.1.6.tgz",
-      "integrity": "sha512-uvlb1rPCKc0ntw9NBpG/V7LfjbTZkyO24Crjo4A4LzLIJCQa1SuwiW802mTFjTp/XOqPKcD48/bft8e2YSF/+w==",
-      "license": "MIT",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@typespec/http-client-java/-/http-client-java-0.1.7.tgz",
+      "integrity": "sha512-7ZgSco+MrzNSYGYWxT2unwuHH9PLTiuUVf3tiZYqz+nim1aCJwfRrJVA1jcVniFcRqIT8FSpDIr9ZhnNj2aREg==",
       "dependencies": {
         "@autorest/codemodel": "~4.20.0",
         "@typespec/http-client-java": "file:",
@@ -899,15 +897,15 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-autorest": ">=0.49.0 <1.0.0",
-        "@azure-tools/typespec-azure-core": ">=0.49.0 <1.0.0",
-        "@azure-tools/typespec-client-generator-core": ">=0.49.0 <1.0.0",
-        "@typespec/compiler": ">=0.63.0 <1.0.0",
-        "@typespec/http": ">=0.63.0 <1.0.0",
-        "@typespec/openapi": ">=0.63.0 <1.0.0",
-        "@typespec/rest": ">=0.63.0 <1.0.0",
-        "@typespec/versioning": ">=0.63.0 <1.0.0",
-        "@typespec/xml": ">=0.63.0 <1.0.0"
+        "@azure-tools/typespec-autorest": ">=0.50.0 <1.0.0",
+        "@azure-tools/typespec-azure-core": ">=0.50.0 <1.0.0",
+        "@azure-tools/typespec-client-generator-core": ">=0.50.0 <1.0.0",
+        "@typespec/compiler": ">=0.64.0 <1.0.0",
+        "@typespec/http": ">=0.64.0 <1.0.0",
+        "@typespec/openapi": ">=0.64.0 <1.0.0",
+        "@typespec/rest": ">=0.64.0 <1.0.0",
+        "@typespec/versioning": ">=0.64.0 <1.0.0",
+        "@typespec/xml": ">=0.64.0 <1.0.0"
       }
     },
     "node_modules/@typespec/http-client-java/node_modules/@typespec/http-client-java": {
@@ -970,9 +968,9 @@
       }
     },
     "node_modules/@typespec/json-schema": {
-      "version": "0.63.0",
-      "resolved": "https://registry.npmjs.org/@typespec/json-schema/-/json-schema-0.63.0.tgz",
-      "integrity": "sha512-jGRXxUxdrwW/XzvaDqyt5mS/V1iBnrDaHUMRIkrFLCwzgll/NenquLI/nopihzLFXK78MfFYuHg4DEPYY5PdFw==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@typespec/json-schema/-/json-schema-0.64.0.tgz",
+      "integrity": "sha512-71E1c58xbHWYSli1Um2U3SQUANPoTp+p87xiH1h64NLlLHMMgFofiQcIb9v1H9tw0YBNB6ELz/zyFGJpZcM3bA==",
       "dependencies": {
         "yaml": "~2.5.1"
       },
@@ -980,25 +978,25 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "~0.63.0"
+        "@typespec/compiler": "~0.64.0"
       }
     },
     "node_modules/@typespec/openapi": {
-      "version": "0.63.0",
-      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-0.63.0.tgz",
-      "integrity": "sha512-/KzR60mj3P/LnNWd/QfH0KTN/If4+mjrsWNSB7/uab6c8Qu/lNsGlZDkmWq4EFiwBR7VmpdFz9FP7d/m3O+tGw==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-0.64.0.tgz",
+      "integrity": "sha512-C4sPdj86ejsNkpmEaAMMqQR+0kq4Ayp4sPKvj4OTtawLXacXKzZ9NYng2jrguO6WbLr5f3NyRZKi7Ys2suT27A==",
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "~0.63.0",
-        "@typespec/http": "~0.63.0"
+        "@typespec/compiler": "~0.64.0",
+        "@typespec/http": "~0.64.0"
       }
     },
     "node_modules/@typespec/openapi3": {
-      "version": "0.63.0",
-      "resolved": "https://registry.npmjs.org/@typespec/openapi3/-/openapi3-0.63.0.tgz",
-      "integrity": "sha512-HC8VeakPznXNn7euAyAxUFNsOcfSzM8tQwYPNUMWs0qGJqGgb6vjf5rShQmfgrCe5Y6zcMM2PPBuxaFV3xXYLw==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@typespec/openapi3/-/openapi3-0.64.0.tgz",
+      "integrity": "sha512-k6WQ/5lTAnlg8TvdzB89W4mO8HhS3MHbdr5VMS4sS8j1K8uCC9xUPR0v+5TF9EDpKpa53LewetzNduP9KjMUmA==",
       "dependencies": {
         "@readme/openapi-parser": "~2.6.0",
         "openapi-types": "~12.1.3",
@@ -1011,61 +1009,65 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "~0.63.0",
-        "@typespec/http": "~0.63.0",
-        "@typespec/openapi": "~0.63.0",
-        "@typespec/versioning": "~0.63.0"
+        "@typespec/compiler": "~0.64.0",
+        "@typespec/http": "~0.64.0",
+        "@typespec/json-schema": "~0.64.0",
+        "@typespec/openapi": "~0.64.0",
+        "@typespec/versioning": "~0.64.0"
       },
       "peerDependenciesMeta": {
+        "@typespec/json-schema": {
+          "optional": true
+        },
         "@typespec/xml": {
           "optional": true
         }
       }
     },
     "node_modules/@typespec/rest": {
-      "version": "0.63.0",
-      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.63.0.tgz",
-      "integrity": "sha512-HftzMjSDHAYX+ILE9C6pFS4oAq7oBHMCtpA8QgSFPDF4V5a8l1k2K8c4x1B+7yl+GkREmIdtpc6S0xZm2G7hXg==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.64.0.tgz",
+      "integrity": "sha512-7+oUajQzOkZPTMtRiGp6hzTTmy7mRaxOYqxIPgDhYyr9I6oQPLAcBsYhFNk/ulcqld/ApaV5ycXaOlK41REOyQ==",
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "~0.63.0",
-        "@typespec/http": "~0.63.0"
+        "@typespec/compiler": "~0.64.0",
+        "@typespec/http": "~0.64.0"
       }
     },
     "node_modules/@typespec/streams": {
-      "version": "0.63.0",
-      "resolved": "https://registry.npmjs.org/@typespec/streams/-/streams-0.63.0.tgz",
-      "integrity": "sha512-4vEd5jdpdaY2i9CDHwSRuiUNCJr+M/gUCwNsaGWgsJdrfR/lx8WX3Y27KcRDNVcRQF7nsOR4i28r4siWqrTM4w==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@typespec/streams/-/streams-0.64.0.tgz",
+      "integrity": "sha512-5Rh5yimdWw16ppX8VmMy/Q7KtUTdKOzwv+EgaEREFOYJ86LWdn8y/EtZ4wDy9iXitxJ6kxDOOfJphaA9DaodfQ==",
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "~0.63.0"
+        "@typespec/compiler": "~0.64.0"
       }
     },
     "node_modules/@typespec/versioning": {
-      "version": "0.63.0",
-      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.63.0.tgz",
-      "integrity": "sha512-BPvmPL+g20yEmSA8XRfbIHdToNOjssq4QfwOU6D7kKLLXnZHFb1hmuwW0tf0Wa/lYgoaUC60ONAeoXgNT1ZOIQ==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.64.0.tgz",
+      "integrity": "sha512-GtmuE7UwVYuVwgSpbSWzZB5UO6O/f/o1NqjLStctF8zkv2/5s+RbeqRyamjDuUyhMrIwqw+TMXtAnMXpSHlB8A==",
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "~0.63.0"
+        "@typespec/compiler": "~0.64.0"
       }
     },
     "node_modules/@typespec/xml": {
-      "version": "0.63.0",
-      "resolved": "https://registry.npmjs.org/@typespec/xml/-/xml-0.63.0.tgz",
-      "integrity": "sha512-2aQxWWqc5f4OTmC2nNafHi+ppr8GqwwMXx/2DnNjeshZF/JD0FNCYH8gV4gFZe7mfRfB9bAxNkcKj2AF01ntqA==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@typespec/xml/-/xml-0.64.0.tgz",
+      "integrity": "sha512-Sk+5S2C4YK+fqSadAlzRBSZbhvtDtxLQUS+vrYgiqzVS1F61nUmP7gQGUj+Kps7ncZSppPZystWJJnF7K34UJg==",
       "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "~0.63.0"
+        "@typespec/compiler": "~0.64.0"
       }
     },
     "node_modules/ajv": {

--- a/package.json
+++ b/package.json
@@ -1,22 +1,22 @@
 {
   "dependencies": {
-    "@azure-tools/typespec-autorest": "^0.49.0",
-    "@azure-tools/typespec-azure-core": "^0.49.0",
-    "@azure-tools/typespec-azure-resource-manager": "^0.49.0",
-    "@azure-tools/typespec-client-generator-core": "^0.49.1",
-    "@typespec/compiler": "^0.63.0",
-    "@typespec/http": "^0.63.0",
+    "@azure-tools/typespec-autorest": "^0.50.0",
+    "@azure-tools/typespec-azure-core": "^0.50.0",
+    "@azure-tools/typespec-azure-resource-manager": "^0.50.0",
+    "@azure-tools/typespec-client-generator-core": "^0.50.0",
+    "@typespec/compiler": "^0.64.0",
+    "@typespec/http": "^0.64.0",
     "@typespec/http-client-csharp": "^0.1.9-alpha.20250113.2",
     "@typespec/http-server-csharp": "https://artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvNDQ2MjEzMi9hcnRpZmFjdE5hbWUvcGFja2FnZXM1/content?format=file&subPath=%2Ftypespec-http-server-csharp-0.58.0-alpha.7-pr-5505.20250108.43.tgz",
     "@typespec/http-server-javascript": "^0.58.0-alpha.6",
-    "@typespec/http-client-java": "^0.1.6",
+    "@typespec/http-client-java": "^0.1.7",
     "@azure-tools/typespec-ts": "^0.37.0",
     "@typespec/http-client-python": "^0.6.0",
-    "@typespec/json-schema": "^0.63.0",
-    "@typespec/openapi": "^0.63.0",
-    "@typespec/openapi3": "^0.63.0",
-    "@typespec/rest": "^0.63.0",
-    "@typespec/streams": "^0.63.0",
-    "@typespec/versioning": "^0.63.0"
+    "@typespec/json-schema": "^0.64.0",
+    "@typespec/openapi": "^0.64.0",
+    "@typespec/openapi3": "^0.64.0",
+    "@typespec/rest": "^0.64.0",
+    "@typespec/streams": "^0.64.0",
+    "@typespec/versioning": "^0.64.0"
   }
 }

--- a/petstore/clients/java/src/main/java/petstore/implementation/PetStoreClientImpl.java
+++ b/petstore/clients/java/src/main/java/petstore/implementation/PetStoreClientImpl.java
@@ -169,8 +169,8 @@ public final class PetStoreClientImpl {
      * @param endpoint Service host.
      */
     public PetStoreClientImpl(HttpPipeline httpPipeline, String endpoint) {
-        this.endpoint = endpoint;
         this.httpPipeline = httpPipeline;
+        this.endpoint = endpoint;
         this.pets = new PetsImpl(this);
         this.petCheckups = new PetCheckupsImpl(this);
         this.petInsurances = new PetInsurancesImpl(this);

--- a/todoApp/clients/java/src/main/java/todo/implementation/TodoClientImpl.java
+++ b/todoApp/clients/java/src/main/java/todo/implementation/TodoClientImpl.java
@@ -85,8 +85,8 @@ public final class TodoClientImpl {
      * @param endpoint Service host.
      */
     public TodoClientImpl(HttpPipeline httpPipeline, String endpoint) {
-        this.endpoint = endpoint;
         this.httpPipeline = httpPipeline;
+        this.endpoint = endpoint;
         this.users = new UsersImpl(this);
         this.todoItems = new TodoItemsImpl(this);
         this.todoItemsAttachments = new TodoItemsAttachmentsImpl(this);

--- a/todoApp/samples/java/src/main/java/todo/TodoSample.java
+++ b/todoApp/samples/java/src/main/java/todo/TodoSample.java
@@ -57,6 +57,7 @@ public final class TodoSample {
         long todoItemId2 = createTodoItemFormResponse.getId();
         System.out.println("todo item created via multipart/form-data, id=" + todoItemId2);
 
+        // create attachment via multipart/form-data
         try {
             todoItemsAttachmentsClient.createFileAttachment(todoItemId2,
                 new FileAttachmentMultipartRequest(


### PR DESCRIPTION
http-client-java 0.1.7 is based on typespec 0.64

There is no meaningful code change. If one need to sync emitter version in another PR, just use `0.1.7` and that's all.