### PR TITLE
remove unused import openapi3 in todoApp

### DIFF
--- a/todoApp/spec/main.tsp
+++ b/todoApp/spec/main.tsp
@@ -1,6 +1,5 @@
 import "@typespec/http";
 import "@typespec/rest";
-import "@typespec/openapi3";
 import "@typespec/openapi";
 import "@typespec/json-schema";
 using Http;


### PR DESCRIPTION
todoApp typespec does not use any api/decorator of @typespec/openapi3 library. Remove the unused import `import @typespec/openapi3`